### PR TITLE
Fix player spawning to work on even in every PC

### DIFF
--- a/FixPatch.cs
+++ b/FixPatch.cs
@@ -83,13 +83,11 @@ namespace Evacuation {
             Transform playerTransform = null;
             Rigidbody playerRigidbody = null;
             OWRigidbody playerOWRigidbody = null;
-            Transform sleepingBagTransform = null;
             SpawnPoint spawnPoint = null;
 
             float timeFromWakingUp = 0;
 
             Vector3 velocity = Vector3.zero;
-            //Vector3 prevPosOfSleepingBag = Vector3.zero;
             Vector3 prevPosOfPlayer = Vector3.zero;
 
             while(true) {
@@ -105,14 +103,6 @@ namespace Evacuation {
                         Evacuation.Log("player is found");
                     }
                 }
-                if(!sleepingBagTransform) {
-                    var sleepingBag = GameObject.Find(SLEEPING_BAG_PATH);
-                    if(sleepingBag) {
-                        sleepingBagTransform = sleepingBag.transform;
-                        //prevPosOfSleepingBag = sleepingBagTransform.position;
-                        Evacuation.Log("sleeping bag is found");
-                    }
-                }
                 if(!spawnPoint) {
                     var campground_body = GameObject.Find(CAMPGROUND_PATH);
                     if(campground_body) {
@@ -123,24 +113,8 @@ namespace Evacuation {
                         }
                     }
                 }
-                if(!playerTransform || !sleepingBagTransform || !spawnPoint) {
+                if(!playerTransform || !spawnPoint) {
                     continue;
-                }
-
-                //playerRigidbody.freezeRotation = true;
-                //velocity = (sleepingBagTransform.position - prevPosOfSleepingBag) / Time.deltaTime;
-                //velocity = (playerTransform.position - prevPosOfPlayer) / Time.fixedDeltaTime;
-                //velocity = (playerTransform.position - prevPosOfPlayer) / Time.deltaTime;
-                //prevPosOfPlayer = playerTransform.position;
-                //Evacuation.Log($"velocity: {velocity}");
-
-                //playerRigidbody.isKinematic = true;
-                if(!float.IsInfinity(velocity.x) && !float.IsNaN(velocity.x)) {
-                    //playerRigidbody.velocity = velocity;
-                    //playerOWRigidbody.SetVelocity(velocity);
-                    //if(!Physics.autoSyncTransforms) {
-                    //    Physics.SyncTransforms();
-                    //}
                 }
 
                 var pos = spawnPoint.transform.position;
@@ -148,25 +122,10 @@ namespace Evacuation {
                 velocity = spawnPoint._attachedBody.GetVelocity() + spawnPoint._attachedBody.GetPointTangentialVelocity(pos);
                 playerOWRigidbody.SetVelocity(velocity);
 
-                float coefficient;
-                //playerTransform.transform.eulerAngles = new Vector3(0, 0, 0);
-                if(_initialWakeUp) {
-                    coefficient = 0.85f;
-                }
-                else {
-                    coefficient = 0.9f;
-                }
-                //playerTransform.position = sleepingBagTransform.transform.position + sleepingBagTransform.transform.up * coefficient;
-                //playerTransform.parent = sleepingBagTransform;
-
                 if(timeFromWakingUp > _wakeLength * 0.8f) {
-                    //playerTransform.parent = null;
-                    //playerRigidbody.isKinematic = false;
-                    //playerRigidbody.freezeRotation = false;
                     yield break;
                 }
                 if(_wakeUp) {
-                    //timeFromWakingUp += Time.fixedDeltaTime;
                     timeFromWakingUp += Time.deltaTime;
                 }
             }

--- a/FixPatch.cs
+++ b/FixPatch.cs
@@ -25,7 +25,13 @@ namespace Evacuation {
             LoadManager.OnCompleteSceneLoad += (scene, loadScene) => {
                 if (loadScene == OWScene.SolarSystem) {
                     Evacuation.Log("SolarSystem is loaded");
+
+                    if(_fixRaftCoroutine != null) {
+                        Evacuation.Instance.StopCoroutine(_fixRaftCoroutine);
+                        _fixRaftCoroutine = null;
+                    }
                     _fixRaftCoroutine = Evacuation.Instance.StartCoroutine(FixRaft());
+
                     _fixPlayerSpawnPosition = Evacuation.Instance.StartCoroutine(FixPlayerSpawnPosition());
                 }
                 else if(loadScene == OWScene.TitleScreen) {
@@ -112,7 +118,7 @@ namespace Evacuation {
                 //velocity = (playerTransform.position - prevPosOfPlayer) / Time.fixedDeltaTime;
                 velocity = (playerTransform.position - prevPosOfPlayer) / Time.deltaTime;
                 prevPosOfPlayer = playerTransform.position;
-                Evacuation.Log($"velocity: {velocity}");
+                //Evacuation.Log($"velocity: {velocity}");
 
                 //playerRigidbody.isKinematic = true;
                 if(!float.IsInfinity(velocity.x) && !float.IsNaN(velocity.x)) {
@@ -205,8 +211,10 @@ namespace Evacuation {
             _isRaftPushed = false;
             _wakeUp = false;
             _initialWakeUp = false;
-            Evacuation.Instance.StopCoroutine(_fixRaftCoroutine);
-            _fixRaftCoroutine = null;
+
+            //Evacuation.Instance.StopCoroutine(_fixRaftCoroutine); // this would move the raft when death (you can see it with closing your eyes)
+            //_fixRaftCoroutine = null;
+
             Evacuation.Instance.StopCoroutine(_fixPlayerSpawnPosition);
             _fixPlayerSpawnPosition = null;
         }

--- a/FixPatch.cs
+++ b/FixPatch.cs
@@ -11,16 +11,25 @@ namespace Evacuation {
     public static class FixPatch {
         static bool _canBeDamaged = false;
         static bool _isRaftPushed = false;
+        static bool _wakeUp = false;
+        static float _wakeLength = 1f;
+        static bool _initialWakeUp = true;
         static Coroutine _fixRaftCoroutine;
+        static Coroutine _fixPlayerSpawnPosition;
 
         const string RAFT_PLATFORM_PATH = "LayeredLagoon_Body/Sector/Prefab_NOM_SimpleChair_NoSkeleton (1)";
         const string RAFT_PATH = "LayeredLagoonRaft_Body";
+        const string SLEEPING_BAG_PATH = "TheCampground_Body/Sector/Props_HEA_CampsiteSleepingBag";
 
         public static void Initialize() {
             LoadManager.OnCompleteSceneLoad += (scene, loadScene) => {
                 if (loadScene == OWScene.SolarSystem) {
                     Evacuation.Log("SolarSystem is loaded");
                     _fixRaftCoroutine = Evacuation.Instance.StartCoroutine(FixRaft());
+                    _fixPlayerSpawnPosition = Evacuation.Instance.StartCoroutine(FixPlayerSpawnPosition());
+                }
+                else if(loadScene == OWScene.TitleScreen) {
+                    _initialWakeUp = true;
                 }
             };
         }
@@ -63,11 +72,90 @@ namespace Evacuation {
             }
         }
 
+        static IEnumerator FixPlayerSpawnPosition() {
+            Transform playerTransform = null;
+            Rigidbody playerRigidbody = null;
+            Transform sleepingBagTransform = null;
+
+            float timeFromWakingUp = 0;
+
+            Vector3 velocity = Vector3.zero;
+            //Vector3 prevPosOfSleepingBag = Vector3.zero;
+            Vector3 prevPosOfPlayer = Vector3.zero;
+
+            while(true) {
+                //yield return new WaitForEndOfFrame();
+                yield return null;
+                if(!playerTransform) {
+                    var player = GameObject.FindObjectOfType<PlayerCharacterController>();
+                    if(player) {
+                        playerTransform = player.transform;
+                        playerRigidbody = player.GetComponent<Rigidbody>();
+                        prevPosOfPlayer = player.transform.position;
+                        Evacuation.Log("player is found");
+                    }
+                }
+                if(!sleepingBagTransform) {
+                    var sleepingBag = GameObject.Find(SLEEPING_BAG_PATH);
+                    if(sleepingBag) {
+                        sleepingBagTransform = sleepingBag.transform;
+                        //prevPosOfSleepingBag = sleepingBagTransform.position;
+                        Evacuation.Log("sleeping bag is found");
+                    }
+                }
+                if(!playerTransform || !sleepingBagTransform) {
+                    continue;
+                }
+
+                //playerRigidbody.freezeRotation = true;
+                //velocity = (sleepingBagTransform.position - prevPosOfSleepingBag) / Time.deltaTime;
+                //velocity = (playerTransform.position - prevPosOfPlayer) / Time.fixedDeltaTime;
+                velocity = (playerTransform.position - prevPosOfPlayer) / Time.deltaTime;
+                prevPosOfPlayer = playerTransform.position;
+                Evacuation.Log($"velocity: {velocity}");
+
+                //playerRigidbody.isKinematic = true;
+                if(!float.IsInfinity(velocity.x) && !float.IsNaN(velocity.x)) {
+                    playerRigidbody.velocity = velocity;
+                }
+
+                float coefficient;
+                //playerTransform.transform.eulerAngles = new Vector3(0, 0, 0);
+                if(_initialWakeUp) {
+                    coefficient = 0.85f;
+                }
+                else {
+                    coefficient = 0.9f;
+                }
+                playerTransform.position = sleepingBagTransform.transform.position + sleepingBagTransform.transform.up * coefficient;
+                //playerTransform.parent = sleepingBagTransform;
+
+                if(timeFromWakingUp > _wakeLength * 0.8f) {
+                    //playerTransform.parent = null;
+                    //playerRigidbody.isKinematic = false;
+                    //playerRigidbody.freezeRotation = false;
+                    yield break;
+                }
+                if(_wakeUp) {
+                    //timeFromWakingUp += Time.fixedDeltaTime;
+                    timeFromWakingUp += Time.deltaTime;
+                }
+            }
+        }
+
         [HarmonyPrefix]
         [HarmonyPatch(typeof(RaftController), nameof(RaftController.OnPressInteract))]
         public static void RaftController_OnPressInteract_Prefix() {
-            Evacuation.Log("Raft is pushed");
+            //Evacuation.Log("Raft is pushed");
             _isRaftPushed = true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(PlayerCameraEffectController), nameof(PlayerCameraEffectController.WakeUp))]
+        public static void PlayerCameraEffectController_WakeUp_Prefix(PlayerCameraEffectController __instance) {
+            _wakeUp = true;
+            _wakeLength = __instance._wakeLength;
+            Evacuation.Log($"Player is wake up. wakeLength: {_wakeLength}");
         }
 
         // Player does not get damaged before using their jetpack.
@@ -115,8 +203,24 @@ namespace Evacuation {
             //Evacuation.Log("Player is dead now");
             _canBeDamaged = false;
             _isRaftPushed = false;
+            _wakeUp = false;
+            _initialWakeUp = false;
             Evacuation.Instance.StopCoroutine(_fixRaftCoroutine);
             _fixRaftCoroutine = null;
+            Evacuation.Instance.StopCoroutine(_fixPlayerSpawnPosition);
+            _fixPlayerSpawnPosition = null;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(DeathManager), nameof(DeathManager.KillPlayer))]
+        public static bool DeathManager_KillPlayer_Prefix(DeathType deathType) {
+            if(deathType == DeathType.Meditation) {
+                return true;
+            }
+            if(_canBeDamaged) {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "author": "2walker2, Texture_Turtle, and Samster68",
   "name": "Evacuation",
   "uniqueName": "2walker2.Evacuation",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "owmlVersion": "2.9.0",
   "dependencies": [ "xen.NewHorizons" ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "author": "2walker2, Texture_Turtle, and Samster68",
   "name": "Evacuation",
   "uniqueName": "2walker2.Evacuation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "owmlVersion": "2.9.0",
   "dependencies": [ "xen.NewHorizons" ]
 }

--- a/planets/LayeredLagoonRaft.json
+++ b/planets/LayeredLagoonRaft.json
@@ -10,7 +10,8 @@
 		"singularities": [
 			{
 				"position": {
-					"y": 50.0
+					"x": -5.0,
+					"y": 55.0
 				},
 				"horizonRadius": 10.0,
 				"distortRadius": 11.0,

--- a/translations/japanese.json
+++ b/translations/japanese.json
@@ -69,7 +69,7 @@
     "Here we are in a completely different solar system, and still the Nomai have left their mark.": "ここで私たちはまったく別の星系にいるが、それでもNomaiはその痕跡を残している。",
     "Do you still have that translator tool? Perhaps you could <![CDATA[<color=orange>go give Riebeck a hand</color>]]>?": "まだあの翻訳機は持っているよな？もしかしたら<![CDATA[<color=orange>Riebeckに手を貸せる</color>]]>かもしれない。",
     "You know how to find them.": "あいつを見つける方法は知っているだろうし。",
-    "It seems to be coming from the <![CDATA[<color=orange>large blue planet</color>]]>. We can't seem to pinpoint it closer than that.": "<![CDATA[<color=orange>大きなあの白い惑星</color>]]>からだ。それ以上はここからだと特定できないな。",
+    "It seems to be coming from the <![CDATA[<color=orange>large blue planet</color>]]>. We can't seem to pinpoint it closer than that.": "<![CDATA[<color=orange>大きなあの灰色の惑星</color>]]>からだ。それ以上はここからだと特定できないな。",
 
     // Porphy
     "The children wouldn't stop pestering me about dinner, so I told them to play the quiet game.": "子どもたちが夜ごはんのことでうるさいから、静かにするゲームをするように言ってるんだ。",


### PR DESCRIPTION
* Fix player spawning to work on even in lower spec PCs.
  * Works on both nh v1.12.2 and v1.13.0.
* To be honestly, in the previous build of Evacuation (v2.1.0), you can move the singularity with death (you can see it with meditation near the singularity). So, I fix it.
* To prevent bypassing the puzzle, the singularity is moved to the gear.

You can test this PR with [this build](https://github.com/TRSasasusu/NHJamTeamErnesto/releases/tag/v2.1.2).